### PR TITLE
Change windows builds to static linking

### DIFF
--- a/.github/workflows/create-artifacts.yml
+++ b/.github/workflows/create-artifacts.yml
@@ -73,13 +73,13 @@ jobs:
           - {
               arch: x86,
               generator: "-G'Visual Studio 16 2019' -A Win32",
-              vcpkg_triplet: x86-windows,
+              vcpkg_triplet: x86-windows-static,
               artifact_name: windows32
             }
           - {
               arch: x64,
               generator: "-G'Visual Studio 16 2019' -A x64",
-              vcpkg_triplet: x64-windows,
+              vcpkg_triplet: x64-windows-static,
               artifact_name: windows64
             }
     steps:
@@ -96,10 +96,10 @@ jobs:
     - name: Build
       run: |
         mkdir build-${{ matrix.config.vcpkg_triplet }} && cd build-${{ matrix.config.vcpkg_triplet }}
-        cmake ${{matrix.config.generator}} -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake" ../
-        cmake --build .
+        cmake ${{matrix.config.generator}} -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="${{ matrix.config.vcpkg_triplet }}" -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded" ../
+        cmake --build . --config Release
     - name: Archive qpakman Windows
       uses: actions/upload-artifact@v4
       with:
         name: qpakman-${{ matrix.config.artifact_name }}
-        path: ./build-${{ matrix.config.vcpkg_triplet }}/Debug/qpakman.exe
+        path: ./build-${{ matrix.config.vcpkg_triplet }}/Release/qpakman.exe


### PR DESCRIPTION
The reason for this change is that a windows user gets confronted with missing dependencie errors when launching the windows build. This fixes this by statically linking the dependencies.

- The main change is done to the target triplet appending the `-static`
- `-DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded" ` is needed for changing the MSVC runtime to static linking
- `-DVCPKG_TARGET_TRIPLET="${{ matrix.config.vcpkg_triplet }}"` is need because othewise cmake doesn't find the dependencies for some reason.
- Changed build to Release mode because otherwise a non developer system complains about missing `ucrtbase.dll`

This has been tested and reported as working by a windows user. It also was flagged as a virus by windows 10 defender.