### PR TITLE
CI: Use macOS 13 for Intel support

### DIFF
--- a/.github/workflows/create-artifacts.yml
+++ b/.github/workflows/create-artifacts.yml
@@ -45,7 +45,7 @@ jobs:
         path: ./build-lin32/qpakman
 
   macos_build:
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       CXX: clang++
     steps:


### PR DESCRIPTION
I had contributed a PR many months ago to use GitHub Actions to deploy Artifacts on new commits. That PR contained an oversight in which GitHub's macOS 14 images are only for Apple Silicon ARM. This just changes the pipeline to use 13 to reinstate Intel support.